### PR TITLE
fixing compat requirements for Molly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,13 +16,12 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
-UnitfulRecipes = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 
 [compat]
 AtomsBase = "0.2"
 Distances = "0.10"
 InteratomicPotentials = "0.2"
-Molly = "0.10"
+Molly = ">= 0.14.3"
 NBodySimulator = "1"
 PeriodicTable = "1"
 Plots = "1"
@@ -30,7 +29,6 @@ Reexport = "1"
 StaticArrays = "1"
 Unitful = "1"
 UnitfulAtomic = "1"
-UnitfulRecipes = "1"
 julia = "1.7"
 
 [extras]

--- a/src/Atomistic.jl
+++ b/src/Atomistic.jl
@@ -15,7 +15,7 @@ using Molly
 using NBodySimulator
 
 using PeriodicTable
-using Plots, UnitfulRecipes
+using Plots
 
 import NBodySimulator: Body, BoundaryConditions, NullThermostat, SimulationResult, Thermostat
 import Plots: Plot


### PR DESCRIPTION
For some zygote compatability reasons, I could only get `Molly >= 0.14.2` or so to build properly, so I set `Molly >= 0.14.3` in the `Project.toml` because that's the current release anyway.

Also removed UnitfulRecipes because it's deprecated 